### PR TITLE
Iamjolly/googletagmanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@ yarn-error.log
 
 # Test artifacts
 cypress/videos/
+cypress/screenshots/
 cypress/fixtures/example.json

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,38 @@ module.exports = {
   },
   pathPrefix: process.env.BASEURL || '/',
   plugins: [
+    { 
+      resolve: "gatsby-plugin-google-tagmanager",
+      options: {
+        id: "GTM-MNT5VXS",
+  
+        // Include GTM in development.
+        //
+        // Defaults to false meaning GTM will only be loaded in production.
+        includeInDevelopment: false,
+  
+        // datalayer to be set before GTM is loaded
+        // should be an object or a function that is executed in the browser
+        //
+        // Defaults to null
+        defaultDataLayer: function () {
+          return {
+            pageType: window.pageType,
+          }
+        },
+  
+        // Specify optional GTM environment details.
+        // gtmAuth: "YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_AUTH_STRING",
+        // gtmPreview: "YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_PREVIEW_NAME",
+        dataLayerName: "spotlight-ui",
+  
+        // Name of the event that is triggered
+        // on every Gatsby route change.
+        //
+        // Defaults to gatsby-route-change
+        routeChangeEventName: "spotlightui_route_change",
+      },
+    },
     `gatsby-plugin-sass`,
     `gatsby-plugin-react-helmet`,
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,7 +35,7 @@ module.exports = {
         // on every Gatsby route change.
         //
         // Defaults to gatsby-route-change
-        routeChangeEventName: "spotlightui_route_change",
+        routeChangeEventName: "gatsby-route-change",
       },
     },
     `gatsby-plugin-sass`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,7 +14,7 @@ module.exports = {
         // Include GTM in development.
         //
         // Defaults to false meaning GTM will only be loaded in production.
-        includeInDevelopment: false,
+        includeInDevelopment: true,
   
         // datalayer to be set before GTM is loaded
         // should be an object or a function that is executed in the browser
@@ -29,7 +29,7 @@ module.exports = {
         // Specify optional GTM environment details.
         // gtmAuth: "YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_AUTH_STRING",
         // gtmPreview: "YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_PREVIEW_NAME",
-        dataLayerName: "spotlight-ui",
+        // dataLayerName: "spotlight-ui",
   
         // Name of the event that is triggered
         // on every Gatsby route change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10505,6 +10505,24 @@
         }
       }
     },
+    "gatsby-plugin-google-tagmanager": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.3.11.tgz",
+      "integrity": "sha512-i3tUFxuTp7CKU1cM4V7uuEcJdI/7lQRB5d02blm08dFv1GDg/nZpuBM03OTXjWec3Y6GEw7N8aiYSJuA0/OrlQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.19.2",
     "gatsby": "^2.21.24",
     "gatsby-image": "^2.4.3",
+    "gatsby-plugin-google-tagmanager": "^2.3.11",
     "gatsby-plugin-manifest": "^2.4.2",
     "gatsby-plugin-offline": "^3.2.1",
     "gatsby-plugin-react-helmet": "^3.3.1",

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -69,24 +69,6 @@ function SEO({ description, lang, meta, title }) {
         },
       ].concat(meta)}
     >
-      <script
-        async
-        type="text/javascript"
-        id="_fed_an_ua_tag"
-        src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"
-      ></script>
-      <script
-        async
-        src="https://www.googletagmanager.com/gtag/js?id=UA-120112176-3"
-      ></script>
-      <script>
-        {`
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-120112176-3');
-`}
-      </script>
     </Helmet>
   );
 }


### PR DESCRIPTION
For [Spotlight issue #610](https://github.com/18F/Spotlight/issues/610):

## Spotlight-UI Site
- Removes legacy Google Analytics and DAP code from seo.js.
- Added Gatsby Google Tag Manage plugin with initial config values set

[😎  Preview this branch's build with GTM in place](https://federalist-05e4f538-b6c2-49a0-a38c-262ad093ad6d.app.cloud.gov/preview/18f/spotlight-ui/iamjolly/googletagmanager/)