### PR TITLE
Add utility for URL search param generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19005,9 +19005,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.1.tgz",
-      "integrity": "sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==",
+      "version": "6.13.6",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
+      "integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -23081,6 +23081,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-search-params-polyfill": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.0.tgz",
+      "integrity": "sha512-MRG3vzXyG20BJ2fox50/9ZRoe+2h3RM7DIudVD2u/GY9MtayO1Dkrna76IUOak+uoUPVWbyR0pHCzxctP/eDYQ=="
     },
     "url-to-options": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-helmet": "^5.2.1",
     "react-redux": "^7.2.2",
     "redux": "^4.0.5",
+    "url-search-params-polyfill": "^8.1.0",
     "uswds": "^2.7.0",
     "uuid": "^7.0.3"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import 'url-search-params-polyfill';
+
 export const flattenObject = (obj, prefix = '') =>
   Object.keys(obj).reduce((acc, k) => {
     const pre = prefix.length ? prefix + '.' : '';
@@ -14,3 +16,11 @@ export const addOptionAll = optionsArr => {
 
 export const customFilterOptions = (filterList, filterName) =>
   filterList.filter(el => Object.keys(el).includes(filterName))[0];
+
+export const buildQueryParams = (obj) => {
+  let query = new URLSearchParams();
+  Object.keys(obj).forEach(key => (
+    query.append(key, obj[key])
+  ));
+  return query.toString();
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,18 @@
+import * as utils from './utils';
+
+describe('buildQueryParams', function() {
+    const query = {
+        fields: ['foo', 'bar'],
+        filter_one: 'baz',
+    }
+    const result =  utils.buildQueryParams(query);
+    it('builds param with array', () => {
+        expect(result).toMatch(/fields=foo%2Cbar/);
+    });
+    it('builds param with single selection', () => {
+        expect(result).toMatch(/filter_one=baz/);
+    });
+    it('builds complete query string', () => {
+        expect(result).toEqual('fields=foo%2Cbar&filter_one=baz');
+    });
+});


### PR DESCRIPTION
I went with URLSearchParams over a custom package like query-string because it's a built-in, and with a polyfill it can support IE11.

More info on URLSearchParams:
https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams

Using this polyfill for IE:
https://www.npmjs.com/package/url-search-params-polyfill